### PR TITLE
python: Add a test which imports common modules and prints their __file__

### DIFF
--- a/record-environment
+++ b/record-environment
@@ -97,6 +97,18 @@ if [ ! -z "$PYTHON" ] ; then
     echo
     echo "sys.path:"
     python -c 'import sys, pprint ; pprint.pprint(sys.path)'
+    echo
+    echo "Key modules":
+    for python in python2 python3 ; do
+	for modname in numpy tensorflow keras pytorch ; do
+            $python -c "from __future__ import print_function
+try:
+    import $modname
+    print('    $python: $modname', $modname.__file__)
+except:
+    print('    $python: $modname not importable')"
+        done
+    done
 fi
 
 


### PR DESCRIPTION
- This is useful for clearly determining when a user has installed
  their own copy of something which is making the official copy.
- We could do some thinking about if "python" and "python3" are both
  needed here.  This is a general problem for some of the previous
  tests, too.  In other tests we have assumed that the virtual/conda
  environment sets the command "python" to be the version they are
  using.